### PR TITLE
logging: golioth: use QCBOR instead of TinyCBOR

### DIFF
--- a/logging/Kconfig
+++ b/logging/Kconfig
@@ -9,7 +9,7 @@ config LOG_BACKEND_GOLIOTH
 	depends on LOG
 	depends on !LOG_IMMEDIATE
 	depends on GOLIOTH
-	select TINYCBOR
+	select QCBOR
 	help
 	  Enable sending logs to Golioth cloud.
 


### PR DESCRIPTION
QCBOR is already used in DFU mechanism, as it provides easier API for
parsing CBOR objects. Reimplement logging backend with QCBOR, so that
there is only single library used for CBOR encoding/decoding, allowing
to share more code between different device services.

Question is whether we want to make the switch now or wait a bit before
QCBOR proves to be the better library for other services (and samples)
as well.

TODO:
- [x] improve error mapping between QCBOR and Zephyr (posix) error codes
- [x] merge #152 
- [x] merge #154

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/61"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>