### PR TITLE
bump Zephyr to tip of 'main'

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: 3f826560aaf81a444018293bd6acce3c339fe150
+      revision: e3144ca68a626314e4d4bbd285b0467a31b93b9c
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
There were many improvements across the tree since the last stable
release. Use the newest Zephyr version to keep up with Zephyr
development.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/66"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

