### PR TITLE
zephyr: provide path to samples/ in module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,5 @@
 build:
   cmake: .
   kconfig: Kconfig
+samples:
+  - samples


### PR DESCRIPTION
This will give information to 'twister' (indirectly by executing
zephyr/scripts/zephyr_module.py first) about where samples are stored.

Related to following comment (from https://devzone.nordicsemi.com/f/nordic-q-a/81347/external-modules-with-visual-studio-code-extension):
> You are correct that the extension looks for samples in specific folders. The convention is to look in <toplevel>/applications or <toplevel>/samples folder. This is a convention for extra modules in NCS such as homekit/find-my. This means that if you modify the west.yml to put your SDK in the top level, i.e., remove the path: