### PR TITLE
system_client: check mbedTLS PSK length at build time and use it for runtime (config) buffer length

### DIFF
--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -328,7 +328,7 @@ void golioth_system_client_start(void)
  * credentials are stored. This means that we need to allocate memory for
  * credentials ourselves.
  */
-static uint8_t golioth_dtls_psk[64];
+static uint8_t golioth_dtls_psk[CONFIG_MBEDTLS_PSK_MAX_LEN];
 static size_t golioth_dtls_psk_len;
 static uint8_t golioth_dtls_psk_id[64];
 static size_t golioth_dtls_psk_id_len;

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -33,6 +33,9 @@ LOG_MODULE_REGISTER(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_LOG_LEVEL);
 #define TLS_PSK			""
 #endif
 
+BUILD_ASSERT(sizeof(TLS_PSK) - 1 <= CONFIG_MBEDTLS_PSK_MAX_LEN,
+	     "PSK exceeds mbedTLS configured maximum PSK length");
+
 #define PSK_TAG			1
 
 #define PING_INTERVAL		(CONFIG_GOLIOTH_SYSTEM_CLIENT_PING_INTERVAL_SEC * 1000)


### PR DESCRIPTION
Check PSK length at build time, so user will be notified early about PSK
being too big for use with mbedTLS.

So far we are fixed on using mbedTLS, so use configured PSK length as
the length of buffer for storing PSK for Golioth.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/79"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

