### PR TITLE
net: golioth: fix mbedTLS PSK length with NCS

### DIFF
--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -33,8 +33,17 @@ LOG_MODULE_REGISTER(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_LOG_LEVEL);
 #define TLS_PSK			""
 #endif
 
+#ifdef CONFIG_MBEDTLS_PSK_MAX_LEN
+#define PSK_MAX_LEN		CONFIG_MBEDTLS_PSK_MAX_LEN
 BUILD_ASSERT(sizeof(TLS_PSK) - 1 <= CONFIG_MBEDTLS_PSK_MAX_LEN,
 	     "PSK exceeds mbedTLS configured maximum PSK length");
+#else
+/*
+ * Support NCS mirror of Zephyr, which does not have CONFIG_MBEDTLS_PSK_MAX_LEN
+ * defined yet.
+ */
+#define PSK_MAX_LEN		64
+#endif
 
 #define PSK_TAG			1
 
@@ -328,7 +337,7 @@ void golioth_system_client_start(void)
  * credentials are stored. This means that we need to allocate memory for
  * credentials ourselves.
  */
-static uint8_t golioth_dtls_psk[CONFIG_MBEDTLS_PSK_MAX_LEN];
+static uint8_t golioth_dtls_psk[PSK_MAX_LEN];
 static size_t golioth_dtls_psk_len;
 static uint8_t golioth_dtls_psk_id[64];
 static size_t golioth_dtls_psk_id_len;


### PR DESCRIPTION
NCS uses downstream Zephyr, which does not have
CONFIG_MBEDTLS_PSK_MAX_LEN introduced yet. Workaround that and assume
maximum 64 bytes of PSK.

Fixes: 7a53ca37fb1b ("net: golioth: system_client: check PSK length at
  build time")
Fixes: d896d0a662d2 ("net: golioth: system_client: use mbedTLS PSK
  length")

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

