### PR TITLE
gitlab-ci: add build.log to artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,7 @@ pre-commit:
     when: always
     paths:
       - reports/*
+      - twister-out/**/build.log
     reports:
       junit: reports/twister.xml
 


### PR DESCRIPTION
This file contains build errors, which are useful for figuring out what
has gone wrong.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

