### PR TITLE
ci: enforce Signed-off-by

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -30,7 +30,4 @@
 --ignore ENOSYS
 
 --no-tree
---no-signoff
---ignore BAD_SIGN_OFF
---ignore COMMIT_MESSAGE
 --exclude patches

--- a/.gitlint
+++ b/.gitlint
@@ -1,2 +1,7 @@
+[general]
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+extra-path=scripts/gitlint
+
 [body-max-line-length]
 line-length=72

--- a/scripts/gitlint/commit_rules.py
+++ b/scripts/gitlint/commit_rules.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from gitlint.rules import CommitRule, RuleViolation
+
+
+class SignedOffBy(CommitRule):
+    """ This rule will enforce that each commit contains a "Signed-off-by" line.
+    We keep things simple here and just check whether the commit body contains a line that starts with "Signed-off-by".
+    """
+
+    # A rule MUST have a human friendly name
+    name = "body-requires-signed-off-by"
+
+    # A rule MUST have an *unique* id, we recommend starting with UC (for User-defined Commit-rule).
+    id = "UC1"
+
+    def validate(self, commit):
+        flags = re.UNICODE
+        flags |= re.IGNORECASE
+        for line in commit.message.body:
+            if line.lower().startswith("signed-off-by"):
+                if not re.search(r"(^)Signed-off-by: ([-'\w.]+) ([-'\w.]+) (.*)", line, flags=flags):
+                    return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
+                else:
+                    return
+        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by:' line", line_nr=1)]


### PR DESCRIPTION
Recently CONTRIBUTING.md was introduced, which states that each commit should have Signed-off-by line. Enforce that in gitlint and checkpatch workflows.

gitlint: https://github.com/golioth/zephyr-sdk/actions/runs/1548716866
checkpatch: https://github.com/golioth/zephyr-sdk/actions/runs/1548716858

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

