### PR TITLE
github-ci: create pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    container:
+      image: kiwicom/pre-commit:2.9.3
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run pre-commit
+        run: |
+          CODE=0 # run pre-commit
+          for CID in `git rev-list --reverse origin/main..`; do
+              git show $CID -s --format='    pre-commit %h ("%s")'
+              git checkout -f -q $CID
+              pre-commit run --color always --show-diff-on-failure --from-ref $CID^ --to-ref $CID || CODE=$?
+          done
+          exit $CODE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^patches/'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -9,6 +9,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.10
     hooks:
       - id: forbid-crlf


### PR DESCRIPTION
This workflow will automatically check if commits are compliant with
configured pre-commit rules.

See how it detects missing newlines: https://github.com/golioth/zephyr-sdk/actions/runs/1548709001

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/135"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

