### PR TITLE
README: remove `west patch` step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,6 @@ Execute this command to download this repository together with all dependencies:
 
    west init -m git@github.com:golioth/zephyr.git --mr main
    west update
-   west patch
 
 Adding Golioth SDK to existing west project
 -------------------------------------------


### PR DESCRIPTION
This command is not required for a long time already. Remove it from
README in order not to confuse users. Leave it in CI (GitHub and
GitLab), as it is handy to be able to test new features from Zephyr from
time to time (without intension of merging those patches to main
branch).

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/144"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

