### PR TITLE
bump Zephyr to tip of main

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -56,7 +56,7 @@ if GOLIOTH_SYSTEM_CLIENT
 
 config GOLIOTH_SYSTEM_CLIENT_STACK_SIZE
 	int "Stack size"
-	default 2048
+	default 3072
 	help
 	  Defines system client thread stack size.
 

--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -54,6 +54,12 @@ config GOLIOTH_SYSTEM_CLIENT
 
 if GOLIOTH_SYSTEM_CLIENT
 
+config GOLIOTH_SYSTEM_CLIENT_STACK_SIZE
+	int "Stack size"
+	default 2048
+	help
+	  Defines system client thread stack size.
+
 config GOLIOTH_SYSTEM_SERVER_HOST
 	string "Server Host"
 	default "coap.golioth.io" if ((NET_NATIVE && NET_IPV4 && DNS_RESOLVER) || NET_SOCKETS_OFFLOAD)

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -320,7 +320,8 @@ static void golioth_system_client_main(void *arg1, void *arg2, void *arg3)
 	}
 }
 
-K_THREAD_DEFINE(golioth_system, 2048, golioth_system_client_main,
+K_THREAD_DEFINE(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_STACK_SIZE,
+		golioth_system_client_main,
 		GOLIOTH_SYSTEM_CLIENT_GET(), NULL, NULL,
 		K_LOWEST_APPLICATION_THREAD_PRIO, 0, SYS_FOREVER_MS);
 

--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -13,9 +13,9 @@ LOG_MODULE_REGISTER(golioth_dfu, LOG_LEVEL_DBG);
 #include <net/golioth/wifi.h>
 
 #include <logging/log_ctrl.h>
-#include <power/reboot.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/reboot.h>
 
 #include "flash.h"
 

--- a/west.yml
+++ b/west.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: 2bf02f4854aae9b936f4c3267699d2dc7ea16bd9
+      revision: c51aa88046ca5c9d687e3e6802b32ddd57dd6de4
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
ESP32 mcuboot support has been integrated in the last few weeks, so bump
Zephyr version in order to support DFU for ESP32 targets.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/145"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

