### PR TITLE
samples: dfu: reference specific revision of readme-espressif.md

### DIFF
--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -70,7 +70,7 @@ Substitute <board> for one of the boards supported by the sample.
 Espressif MCUboot target
 ------------------------
 
-Follow https://github.com/mcu-tools/mcuboot/blob/main/docs/readme-espressif.md
+Follow https://github.com/mcu-tools/mcuboot/blob/399720d1cabd26c4356445d351f263b31e942961/docs/readme-espressif.md
 on how to build and flash MCUboot.
 
 Building the sample application


### PR DESCRIPTION
This (currently old) version of readme-espressif.md file specifies
offset of bootloader when flashing it on target, while the newest
version (on tip of main) does not reference any specific value and it is
not trivial to figure it out.

As this readme file might quickly evolve over time, let's stick to a
last "known to work" version of it.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

