### PR TITLE
logging: v2 fixes and improvements

### DIFF
--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -536,7 +536,7 @@ static int log_msg_process(struct golioth_log_ctx *ctx, struct log_msg *msg)
 
 	err = log_packet_prepare(ctx);
 	if (err) {
-		return err;
+		goto finish;
 	}
 
 	if (log_msg_is_std(msg)) {
@@ -548,21 +548,22 @@ static int log_msg_process(struct golioth_log_ctx *ctx, struct log_msg *msg)
 	}
 
 	if (err) {
-		return err;
+		goto finish;
 	}
 
 	err = log_packet_finish(ctx);
 	if (err) {
-		return err;
+		goto finish;
 	}
 
 	golioth_send_coap(ctx->client, &ctx->coap_packet);
 
+finish:
 	ctx->msg_index++;
 
 	log_msg_put(msg);
 
-	return 0;
+	return err;
 }
 
 static void send_output(const struct log_backend *const backend,
@@ -603,7 +604,7 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 
 	err = log_packet_prepare(ctx);
 	if (err) {
-		return err;
+		goto finish;
 	}
 
 	log_cbor_create_map(ctx, CborIndefiniteLength);
@@ -633,7 +634,7 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 		}
 
 		if (err) {
-			return err;
+			goto finish;
 		}
 
 		err = cbpprintf(cbprintf_out_func, ctx, data);
@@ -663,7 +664,7 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 
 		err = log_pdu_prepare(pdu, cbor);
 		if (err) {
-			return err;
+			goto finish;
 		}
 
 		if (len > pdu->end - pdu->begin) {
@@ -680,14 +681,15 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 
 	err = log_packet_finish(ctx);
 	if (err) {
-		return err;
+		goto finish;
 	}
 
 	golioth_send_coap(ctx->client, &ctx->coap_packet);
 
+finish:
 	ctx->msg_index++;
 
-	return 0;
+	return err;
 }
 
 static void process(const struct log_backend *const backend,

--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -154,10 +154,6 @@ static void log2_cbor_append_headers(struct golioth_log_ctx *ctx,
 	struct golioth_cbor_ctx *cbor = &ctx->cbor;
 	void *source = (void *)log_msg2_get_source(msg);
 
-	cbor_encode_text_stringz(&cbor->map, "uptime");
-	cbor_encode_uint(&cbor->map,
-			log_output_timestamp_to_us(log_msg2_get_timestamp(msg)));
-
 	if (source) {
 		uint8_t domain_id = log_msg2_get_domain(msg);
 		int16_t source_id =
@@ -611,6 +607,10 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 	}
 
 	log_cbor_create_map(ctx, CborIndefiniteLength);
+
+	cbor_encode_text_stringz(&cbor->map, "uptime");
+	cbor_encode_uint(&cbor->map,
+			 log_output_timestamp_to_us(log_msg2_get_timestamp(msg)));
 
 	if (!raw_string) {
 		log2_cbor_append_headers(ctx, msg);

--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -616,6 +616,9 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 		log2_cbor_append_headers(ctx, msg);
 	}
 
+	cbor_encode_text_stringz(&cbor->map, "index");
+	cbor_encode_uint(&cbor->map, ctx->msg_index);
+
 	size_t len;
 	uint8_t *data = log_msg2_get_package(msg, &len);
 

--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -624,11 +624,10 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 	uint8_t *data = log_msg2_get_package(msg, &len);
 
 	if (len) {
-		const uint8_t *colon;
+		const uint8_t *func_colon = NULL;
 
 		if (has_func) {
 			err = log_pdu_prepare_ext(pdu, cbor, 2, sizeof("func") + 1);
-			colon = find_colon(pdu->begin, pdu->ptr);
 		} else {
 			err = log_pdu_prepare(pdu, cbor);
 		}
@@ -642,12 +641,16 @@ static int log_msg2_process(struct golioth_log_ctx *ctx, struct log_msg2 *msg)
 		(void)err;
 		__ASSERT_NO_MSG(err >= 0);
 
-		if (has_func && colon) {
-			const uint8_t *post_colon = colon + sizeof(": ") - 1;
+		if (has_func) {
+			func_colon = find_colon(pdu->begin, pdu->ptr);
+		}
+
+		if (func_colon) {
+			const uint8_t *post_colon = func_colon + sizeof(": ") - 1;
 
 			cbor_encode_text_stringz(&cbor->map, "func");
 			cbor_encode_text_string(&cbor->map, pdu->begin,
-						colon - pdu->begin);
+						func_colon - pdu->begin);
 
 			cbor_encode_text_stringz(&cbor->map, "msg");
 			cbor_encode_text_string(&cbor->map, post_colon,


### PR DESCRIPTION
Timestamp is saved for raw mesages in logging v2, so send 'uptime', so
that cloud has that information as well.

Message index was correctly calculated, but actually never sent to
Golioth cloud. Start sending it now.

In case of logging v1 there was a possibility that log_msg_put()
was *not* called if an error occurred during processing. This resulted
in log message leak. Fix that.

In case of logging v1 and v2 message logging index was not incremented
in case of error, so make sure to do it correctly now.

Function name was never found, because colon (after "funcname:") was
never being search for in a proper buffer.

Make sure to first let cbprintf() be called, so that function name gets
propagated into the buffer and then search for colon in that buffer in
order to find function name.