### PR TITLE
README: fix link used with 'west init'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Execute this command to download this repository together with all dependencies:
 
 .. code-block:: console
 
-   west init -m git@github.com:golioth/zephyr.git --mr main
+   west init -m https://github.com/golioth/zephyr-sdk.git --mr main
    west update
 
 Adding Golioth SDK to existing west project

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Execute this command to download this repository together with all dependencies:
 
 .. code-block:: console
 
-   west init -m https://github.com/golioth/zephyr-sdk.git --mr main
+   west init -m https://github.com/golioth/zephyr-sdk.git
    west update
 
 Adding Golioth SDK to existing west project


### PR DESCRIPTION
Use https instead of git, which will allow users with read-only access
to initialize repository.

Also use 'zephyr-sdk.git' instead of 'zephyr.git', which is due to
project rename few months ago.

'west init' implicitly uses 'main' branch, so there is no need to
specify that explicitly anymore.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/153"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

