### PR TITLE
net: golioth: fix decomposing path into URI-Path options

### DIFF
--- a/net/golioth/CMakeLists.txt
+++ b/net/golioth/CMakeLists.txt
@@ -1,3 +1,3 @@
-zephyr_library_sources_ifdef(CONFIG_GOLIOTH golioth.c)
+zephyr_library_sources_ifdef(CONFIG_GOLIOTH coap_utils.c golioth.c)
 zephyr_library_sources_ifdef(CONFIG_GOLIOTH_FW fw.c)
 zephyr_library_sources_ifdef(CONFIG_GOLIOTH_SYSTEM_CLIENT system_client.c)

--- a/net/golioth/coap_utils.c
+++ b/net/golioth/coap_utils.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "coap_utils.h"
+
+#include <net/coap.h>
+
+int coap_packet_append_uri_path_from_string_range(struct coap_packet *packet,
+						  const char *begin,
+						  const char *end)
+{
+	const char *p;
+	int err;
+
+	/* Trim preceding '/' */
+	while (*begin == '/') {
+		begin++;
+	}
+
+	p = begin;
+
+	/* Split path into URI-Path options */
+	while (p < end && *p != '\0') {
+		if (*p == '/') {
+			err = coap_packet_append_option(packet,
+							COAP_OPTION_URI_PATH,
+							begin, p - begin);
+			if (err) {
+				return err;
+			}
+
+			begin = p + 1;
+		}
+
+		p++;
+	}
+
+	/* Return early if the last segment is empty */
+	if (begin == p) {
+		return 0;
+	}
+
+	/* Append last segment */
+	return coap_packet_append_option(packet,
+					 COAP_OPTION_URI_PATH,
+					 begin, p - begin);
+}

--- a/net/golioth/coap_utils.h
+++ b/net/golioth/coap_utils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __NET_GOLIOTH_COAP_UTILS_H__
+#define __NET_GOLIOTH_COAP_UTILS_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct coap_packet;
+
+int coap_packet_append_uri_path_from_string_range(struct coap_packet *packet,
+						  const char *begin, const char *end);
+
+static inline int coap_packet_append_uri_path_from_string(struct coap_packet *packet,
+							  const char *path, size_t path_len)
+{
+	return coap_packet_append_uri_path_from_string_range(packet, path, path + path_len);
+}
+
+static inline int coap_packet_append_uri_path_from_stringz(struct coap_packet *packet,
+							   const char *path)
+{
+	return coap_packet_append_uri_path_from_string_range(packet, path, (void *)UINTPTR_MAX);
+}
+
+#endif /* __NET_GOLIOTH_COAP_UTILS_H__ */

--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Golioth, Inc.
+ * Copyright (c) 2021-2022 Golioth, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,8 @@
 #include <qcbor/qcbor.h>
 #include <qcbor/qcbor_spiffy_decode.h>
 #include <stdio.h>
+
+#include "coap_utils.h"
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(golioth);
@@ -153,9 +155,7 @@ int golioth_fw_observe_desired(struct golioth_client *client,
 		return err;
 	}
 
-	err = coap_packet_append_option(&packet, COAP_OPTION_URI_PATH,
-					GOLIOTH_FW_DESIRED,
-					sizeof(GOLIOTH_FW_DESIRED) - 1);
+	err = coap_packet_append_uri_path_from_stringz(&packet, GOLIOTH_FW_DESIRED);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;
@@ -195,8 +195,7 @@ static int golioth_fw_download_next(struct golioth_fw_download_ctx *ctx)
 		return err;
 	}
 
-	err = coap_packet_append_option(&request, COAP_OPTION_URI_PATH,
-					ctx->uri, ctx->uri_len);
+	err = coap_packet_append_uri_path_from_string(&request, ctx->uri, ctx->uri_len);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;
@@ -337,8 +336,7 @@ int golioth_fw_report_state(struct golioth_client *client,
 		return -ENOMEM;
 	}
 
-	err = coap_packet_append_option(&packet, COAP_OPTION_URI_PATH,
-					uri, written);
+	err = coap_packet_append_uri_path_from_string(&packet, uri, written);
 	if (err) {
 		LOG_ERR("failed to append logs uri path: %d", err);
 		return err;

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Golioth, Inc.
+ * Copyright (c) 2021-2022 Golioth, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,8 @@
 #include <random/rand32.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "coap_utils.h"
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(golioth, CONFIG_GOLIOTH_LOG_LEVEL);
@@ -444,8 +446,7 @@ int golioth_lightdb_get(struct golioth_client *client, const uint8_t *path,
 		return err;
 	}
 
-	err = coap_packet_append_option(&packet, COAP_OPTION_URI_PATH,
-					path, strlen(path));
+	err = coap_packet_append_uri_path_from_stringz(&packet, path);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;
@@ -481,8 +482,7 @@ int golioth_lightdb_set(struct golioth_client *client, const uint8_t *path,
 		return err;
 	}
 
-	err = coap_packet_append_option(&packet, COAP_OPTION_URI_PATH,
-					path, strlen(path));
+	err = coap_packet_append_uri_path_from_stringz(&packet, path);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;
@@ -518,8 +518,7 @@ static int golioth_coap_observe_init(struct coap_packet *packet,
 		return err;
 	}
 
-	err = coap_packet_append_option(packet, COAP_OPTION_URI_PATH,
-					path, strlen(path));
+	err = coap_packet_append_uri_path_from_stringz(packet, path);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;
@@ -747,8 +746,7 @@ static int golioth_blockwise_request_next(struct golioth_blockwise_observe_ctx *
 		return err;
 	}
 
-	err = coap_packet_append_option(&request, COAP_OPTION_URI_PATH,
-					ctx->path, strlen(ctx->path));
+	err = coap_packet_append_uri_path_from_stringz(&request, ctx->path);
 	if (err) {
 		LOG_ERR("Unable add uri path to packet");
 		return err;


### PR DESCRIPTION
Each path component (usually delimited by slash) should be encoded in
separate URI-Path option, instead of encoding whole path (includding
slashes) into single URI-Path.

Introduce coap_packet_append_uri_path_from_* helper functions:
 - *_from_string_range - gets pointer to 'begin' and 'end' of string,
 - *_from_string - gets pointer to string and its length,
 - *_from_stringz - gets pointer to NULL-terminated string.

Replace previous invocations of coap_packet_append_option(packet,
COAP_OPTION_URI_PATH, ...) with above functions, so that path is
properly decomposed into multiple URI-Path CoAP options.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/161"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

