### PR TITLE
samples: lightdb: observe: use '/counter' resource

### DIFF
--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -175,12 +175,12 @@ This is the output from the serial console:
 Set the observed value
 ======================
 
-The device retrieves the value stored at ``/observed`` in LightDB and then
+The device retrieves the value stored at ``/counter`` in LightDB and then
 retrieves it every time that it's updated. The value can be updates as such:
 
 .. code-block:: console
 
-   goliothctl lightdb set <device-name> /observed -b "{\"m\":\"new\"}"
+   goliothctl lightdb set <device-name> /counter -b "{\"m\":\"new\"}"
 
 
 .. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu

--- a/samples/lightdb/observe/src/main.c
+++ b/samples/lightdb/observe/src/main.c
@@ -18,7 +18,7 @@ static struct coap_reply coap_replies[1];
 
 /*
  * This function is registed to be called when the data
- * stored at `/observed` changes.
+ * stored at `/counter` changes.
  */
 static int on_update(const struct coap_packet *response,
 		     struct coap_reply *reply,
@@ -61,14 +61,14 @@ static void golioth_on_connect(struct golioth_client *client)
 					       ARRAY_SIZE(coap_replies));
 
 	/*
-	 * Observe the data stored at `/observed` in LightDB.
+	 * Observe the data stored at `/counter` in LightDB.
 	 * When that data is updated, the `on_update` callback
 	 * will be called.
 	 * This will get the value when first called, even if
 	 * the value doesn't change.
 	 */
 	err = golioth_lightdb_observe(client,
-				      GOLIOTH_LIGHTDB_PATH("observed"),
+				      GOLIOTH_LIGHTDB_PATH("counter"),
 				      COAP_CONTENT_FORMAT_TEXT_PLAIN,
 				      observe_reply, on_update);
 


### PR DESCRIPTION
So far '/observed' resource was used in this sample, while other samples
used '/counter' resource. Use the latter, so that the same 'goliothctl
...' commands can be used for multiple samples. This will hopefully
reduce confusion for user when switching back and forth from
'ligthdb/get' and 'lightdb/observe' samples.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/163"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

