### PR TITLE
github: new Github feature request and bug report forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,54 +1,59 @@
-name: Bug Report
+name: 🐞 Bug Report
 description: File a bug report
-title: "[Bug]: "
-labels: ["bug", "triage"]
+labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
   - type: input
-    id: hardware-target
+    id: zephyr-version
     attributes:
-      label: Hardware Target
+      label: Zephyr Commit hash
+      description: Run `git show HEAD -s --format='%H'` in your copy of the Zephyr repository
     validations:
       required: true
   - type: input
     id: dsdk-version
     attributes:
-      label: Golioth Dsdk Commit Hash
+      label: Golioth SDK Commit Hash
+      description: Run `git show HEAD -s --format='%H'` in your copy of the Golioth SDK repository
     validations:
       required: true
-  - type: dropdown
+  - type: input
+    id: hardware-target
+    attributes:
+      label: Hardware Target
+      description: What hardware platform are you using? (e.g. nRF91, ESP32, QEMU, ...)
+    validations:
+      required: false
+  - type: textarea
     id: host-os
     attributes:
-      label: What Host OS are you using?
-      multiple: true
-      options:
-        - Windows
-        - Mac
-        - Ubuntu
-        - Other (Mention Below)
+      label: What host OS are you using?
+      description: Linux users, please share the contents of /etc/os-release (`cat /etc/os-release`)
   - type: textarea
-    id: what-happened
+    id: current-behavior
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
     validations:
-      required: true
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      label: Logs, console output, or any kind of debug information
+      description: Please copy and paste any relevant debug information. This will be automatically formatted into code, so no need for backticks.
       render: shell
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/golioth/zephyr-sdk/blob/main/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Github Discussions
-    url: https://github.com/golioth/zephyr-sdk/discussions
-    about: Feature requests or product questions?
   - name: Discord
     url: https://discord.com/invite/qKjmvzMVYR
-    about: Communicate with us in a less asynchronous fashion here.
+    about: Chat with the community and our team on Discord. Office hours at 10:00am PST every Wednesday!

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,18 @@
+name: 🚀 Feature request
+description: Suggest new features or enhancements to existing features
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the feature
+      description: A concise description of the functionality you would like to have
+    validations:
+      required: true
+  - type: input
+    id: feature-reference
+    attributes:
+      label: Existing feature reference
+      description: Does this request relate to an existing feature? If so, please provide its name.
+    validations:
+      required: false


### PR DESCRIPTION
We were missing an easy way to file a feature request. The new forms add the ability to pick between filing a bug (with less mandatory fields) and filing a feature request.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/167"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

