### PR TITLE
samples: dfu: fix example commands and improve description

### DIFF
--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -7,6 +7,12 @@ Overview
 This DFU application demonstrates how to connect with Golioth and use Device
 Firmware Upgrade (DFU) procedure.
 
+The app is first built and flashed to the device which will then listen to
+Golioth Cloud for a new firmware binary to become available. A second binary is
+built with a new version number, registered as an artifact, and deployed as a
+release. The device will detect this change and automatically download and
+install.
+
 Requirements
 ************
 

--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -220,14 +220,14 @@ Run following command on host PC to upload new firmware as artifact to Golioth:
 
 .. code-block:: console
 
-   $ goliothctl artifact create new.bin --version 1.2.3
+   $ goliothctl dfu artifact create new.bin --version 1.2.3
 
 Then create new release consisting of this single firmware and roll it out to
 all devices in a project:
 
 .. code-block:: console
 
-   $ goliothctl release --release-tags 1.2.3 --components main@1.2.3 --rollout true
+   $ goliothctl dfu release create --release-tags 1.2.3 --components main@1.2.3 --rollout true
 
 DFU process should be started in Zephyr and this is what should be visible on
 serial console:


### PR DESCRIPTION
The sample commands for creating an artifact and a release were missing some keywords and have been corrected. I also added a paragraph to the overview of the sample to better explain the flow.