### PR TITLE
samples: fix mcumgr commands

### DIFF
--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -32,7 +32,7 @@ Enter bootloader and use ``mcumgr`` to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 Now rebuild application with assigned new version to 1.2.3 to distinguish it
 from old firmware:

--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/lightdb/get/README.rst
+++ b/samples/lightdb/get/README.rst
@@ -141,7 +141,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/lightdb/set/README.rst
+++ b/samples/lightdb/set/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/lightdb_stream/README.rst
+++ b/samples/lightdb_stream/README.rst
@@ -144,7 +144,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 

--- a/samples/logging/README.rst
+++ b/samples/logging/README.rst
@@ -142,7 +142,7 @@ Enter bootloader and use ``mcumgr`` (or ``newtmgr``) to flash firmware:
 
 .. code-block:: console
 
-   $ mcumgr --conntype serial --connstring /dev/ttyUSB0,baudrate=1000000 build/zephyr/app_update.bin
+   $ mcumgr --conntype=serial --connstring='dev=/dev/ttyUSB0,baud=1000000' image upload build/zephyr/app_update.bin
 
 See `nRF9160 Feather Programming and Debugging`_ for details.
 


### PR DESCRIPTION
mcumgr flash commands were missing keywords and formatting

Signed-off-by: Mike Szczys <mike@golioth.io>

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

