### PR TITLE
github: upload twister build logs and reports as artifacts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,3 +38,11 @@ jobs:
       - name: Run twister
         run: |
           zephyr/scripts/twister -T modules/lib/golioth
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: twister-artifacts
+          path: |
+            reports/*
+            twister-out/**/build.log


### PR DESCRIPTION
This will allow to further debug issues in CI, without having to run
twister locally.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/170"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

