### PR TITLE
net: golioth: use zsock_ prefix with freeaddrinfo()

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -146,7 +146,7 @@ static int __golioth_connect(struct golioth_client *client, int *sock,
 		}
 	}
 
-	freeaddrinfo(addrs);
+	zsock_freeaddrinfo(addrs);
 
 	return err;
 }


### PR DESCRIPTION
Just be consistent with other APIs, where zsock_ variants are used
instead of the POSIX equivalents.