### PR TITLE
github: always upload twister artifacts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: twister-artifacts
           path: |


### PR DESCRIPTION
Always upload twister artifacts, even in case of failure.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/173"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

