### PR TITLE
README: update links to Zephyr RTOS documentation to point to 3.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,8 +182,8 @@ Device matrix
 +------------------+--------------+----------------------------------------+----------+
 
 .. _Zephyr RTOS: https://www.zephyrproject.org/
-.. _west: https://docs.zephyrproject.org/latest/guides/west/index.html
-.. _Zephyr Getting Started: https://docs.zephyrproject.org/latest/getting_started/index.html
+.. _west: https://docs.zephyrproject.org/3.0.0/guides/west/index.html
+.. _Zephyr Getting Started: https://docs.zephyrproject.org/3.0.0/getting_started/index.html
 .. _nRF Connect SDK: https://www.nordicsemi.com/Software-and-tools/Software/nRF-Connect-SDK
 .. _nRF Connect SDK Getting Started: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html
 .. _nRF9160 Feather: https://www.jaredwolff.com/store/nrf9160-feather/

--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -329,8 +329,8 @@ running from primary area (first application slot):
      copy done: unset
      image ok: unset
 
-.. _MCUboot: https://docs.zephyrproject.org/latest/guides/device_mgmt/dfu.html#mcuboot
-.. _Signing Binaries: https://docs.zephyrproject.org/latest/guides/west/sign.html#west-sign
-.. _Flash map: https://docs.zephyrproject.org/latest/reference/storage/flash_map/flash_map.html#flash-map-api
+.. _MCUboot: https://docs.zephyrproject.org/3.0.0/guides/device_mgmt/dfu.html#mcuboot
+.. _Signing Binaries: https://docs.zephyrproject.org/3.0.0/guides/west/sign.html#west-sign
+.. _Flash map: https://docs.zephyrproject.org/3.0.0/reference/storage/flash_map/flash_map.html#flash-map-api
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -175,7 +175,7 @@ This is the output from the serial console:
 Responses to Hello messages are printed above as a hexdump of "Hello mark". This
 means that communication with Golioth is working.
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -176,7 +176,7 @@ This is the output from the serial console:
    [00:04:14.181,000] <inf> golioth_system: Client connected!
    [00:04:14.898,000] <inf> golioth_system: Disconnect request
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/lightdb/get/README.rst
+++ b/samples/lightdb/get/README.rst
@@ -196,7 +196,7 @@ The value can be set with:
    goliothctl lightdb set <device-name> /counter -b "{\"counter\":34}"
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -189,7 +189,7 @@ retrieves it every time that it's updated. The value can be updates as such:
    goliothctl lightdb set <device-name> /counter -b "{\"m\":\"new\"}"
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/lightdb/set/README.rst
+++ b/samples/lightdb/set/README.rst
@@ -181,7 +181,7 @@ with its value. Current value can be fetched using following command:
    goliothctl lightdb get <device-name> /counter
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -216,7 +216,7 @@ as:
 - ``/aliases/led3``
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/lightdb_stream/README.rst
+++ b/samples/lightdb_stream/README.rst
@@ -249,7 +249,7 @@ Historical data can be queried using following command:
    ]
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/logging/README.rst
+++ b/samples/logging/README.rst
@@ -212,7 +212,7 @@ This is how logs are visible
    [2021-04-08 14:20:32 +0000 UTC] level:DEBUG module:"golioth_logging" message:"Log 2: 0" metadata:{fields:{key:"func" value:{string_value:"func_2"}} fields:{key:"index" value:{number_value:8}} fields:{key:"uptime" value:{number_value:100000}}} device_id:"xxxxxxxxxxxxxxxxxxxxxxxx"
    [2021-04-08 14:20:32 +0000 UTC] level:DEBUG module:"golioth_logging" message:"Log 1: 0" metadata:{fields:{key:"func" value:{string_value:"func_1"}} fields:{key:"index" value:{number_value:7}} fields:{key:"uptime" value:{number_value:100000}}} device_id:"xxxxxxxxxxxxxxxxxxxxxxxx"
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html
 .. _nRF9160 Feather Programming and Debugging: https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html

--- a/samples/settings/README.rst
+++ b/samples/settings/README.rst
@@ -146,6 +146,6 @@ This is the output from the serial console of nRF52840 DK + ESP32-WROOM-32:
    [00:00:10.561,370] <inf> golioth_hello: Sending hello! 1
    [00:00:15.565,368] <inf> golioth_hello: Sending hello! 2
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/latest/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/latest/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html


### PR DESCRIPTION
So far links to 'latest' Zephyr RTOS documentation were used. All those
are broken at this moment except link to 'ESP32' board.

Update all of those (including ESP32 board link, for consistency) to
version 3.0.0 of Zephyr RTOS. Currently the recommended Zephyr RTOS
version (the one pointed to from `west.yml`) is somewhere between 2.7.0
and 3.0.0, so the latter is the best candidate as of now.

In future all links to Zephyr RTOS documentation (and any other
versioned documentation) need to be adjusted together with the component
version that is used.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Fixes: #181 