### PR TITLE
samples: hello_sporadic: sync sample.yaml with hello sample

### DIFF
--- a/samples/hello_sporadic/sample.yaml
+++ b/samples/hello_sporadic/sample.yaml
@@ -3,7 +3,15 @@ sample:
   name: hello
 common:
   harness: net
-  platform_allow: esp32 qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
+  platform_allow: >
+    circuitdojo_feather_nrf9160_ns
+    esp32
+    esp32c3_devkitm
+    nrf52840dk_nrf52840
+    nrf9160dk_nrf9160_ns
+    thingy91_nrf9160_ns
+    qemu_cortex_m3
+    qemu_x86
   tags: golioth net socket
 tests:
   sample.golioth.hello: {}


### PR DESCRIPTION
Both 'hello' and 'hello_sporadic' samples support the same set of
boards. Sync sample.yaml, so that all 'hello_sporadic' is build tested
for all boards.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/184"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

