### PR TITLE
Add file west-ncs.yml, for using SDK as manifest repo with NCS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,30 +49,16 @@ Using with nRF Connect SDK
 ==========================
 
 Platforms like `nRF9160 Feather`_ require `nRF Connect SDK`_ to make use of
-their distinct features, which is cellular network connectivity. Initialize nRF
-Connect SDK with following command:
+their distinct features, which is cellular network connectivity.
+
+Using Golioth SDK as manifest repository
+----------------------------------------
+
+Execute this command to download this repository together with all dependencies:
 
 .. code-block:: console
 
-   west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1
-
-Add following entry to ``west.yml`` file in ``manifest/projects`` subtree:
-
-.. code-block:: yaml
-
-    # Golioth repository.
-    - name: golioth
-      path: modules/lib/golioth
-      revision: main
-      url: https://github.com/golioth/zephyr-sdk.git
-      import:
-        name-allowlist:
-          - qcbor
-
-Now clone all repositories with:
-
-.. code-block:: console
-
+   west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml
    west update
 
 Follow `nRF Connect SDK Getting Started`_ for details on how to setup nRF

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -1,0 +1,21 @@
+# NCS Workflow 4: Application as the manifest repo
+# https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/dm_adding_code.html
+manifest:
+  remotes:
+    - name: ncs
+      url-base: http://github.com/nrfconnect
+  projects:
+    - name: nrf
+      repo-path: sdk-nrf
+      remote: ncs
+      revision: v1.7.1
+      import: true
+
+    - name: qcbor
+      revision: 17b5607b8c49b835d22dec3effa97b25c89267b3
+      url: https://github.com/golioth/QCBOR.git
+      path: modules/lib/qcbor
+
+  self:
+    path: modules/lib/golioth
+    west-commands: scripts/west-commands.yml


### PR DESCRIPTION
JIRA: https://golioth.atlassian.net/browse/DSDK-215

This is intended to be used in scenarios where our SDK is the manifest
repo, as described in NCS's Workflow 4:
https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/dm_adding_code.html#workflow-4-application-as-the-manifest-repository

Previously, we were manually editing NCS's
west.yml to include the Golioth SDK, but this was manual and error-prone,
and it was too easy to select an invalid/non-working version of NCS.

Adding west-ncs.yml allows us to use NCS the same way we use vanilla
Zephyr for cases where the SDK is used as the manifest repo. The version
of NCS is pinned in this .yml, which avoids external users having to
manually select the NCS version, or add the Golioth SDK as a module in
NCS's west.yml.

Signed-off-by: Nick Miller <nick@golioth.io>


### Testing

To test, I ran through a few common dev workflows we use internally at Golioth, to make sure it was an improvement over the older way of dealing with NCS.

- [x] Install SDK with Zephyr
```
    cd ~
    west init -m https://github.com/golioth/zephyr-sdk.git --mr nick/west-ncs --mf west.yml golioth-zephyr-sdk
    cd golioth-zephyr-sdk
    west update
    west zephyr-export
    west espressif update
    west espressif install
```
- [x] Install SDK with NCS
```
    cd ~
    west init -m https://github.com/golioth/zephyr-sdk.git --mr nick/west-ncs --mf west-ncs.yml golioth-ncs-sdk
    cd golioth-ncs-sdk
    west update
    west zephyr-export
```
- [x] Make Zephyr SDK change, build OOT sample to ensure change is picked up
```
    cd ~/src/samples/desired-state
    rm -rf build
    <vanilla zephyr environment setup>
    west build -b nrf52840dk_nrf5840 . -p
    <verify successful build>
    <delete semicolon in ~/golioth-zephyr-sdk/modules/lib/golioth/net/golioth/golioth.c to force compile error>
    west build -b nrf52840dk_nrf5840 . -p
    <verify failed build>
```
- [x] Make Zephyr SDK change, build in-tree sample to ensure change is picked up
```
    cd ~/golioth-zephyr-sdk/modules/lib/golioth/samples/settings
    rm -rf build
    <vanilla zephyr environment setup>
    west build -b nrf52840dk_nrf5840 . -p
    <verify successful build>
    <delete semicolon in ~/golioth-zephyr-sdk/modules/lib/golioth/net/golioth/golioth.c to force compile error>
    west build -b nrf52840dk_nrf5840 . -p
    <verify failed build>
```
- [x] Make NCS SDK change, build OOT sample to ensure change is picked up
```
    cd ~/src/samples/desired-state
    rm -rf build
    <NCS environment setup>
    west build -b nrf9160dk_nrf9160_ns . -p
    <verify successful build>
    <delete semicolon in ~/golioth-ncs-sdk/modules/lib/golioth/net/golioth/golioth.c to force compile error>
    west build -b nrf9160dk_nrf9160_ns . -p
    <verify failed build>
```
- [x] Make NCS SDK change, build in-tree sample to ensure change is picked up
```
    cd ~/golioth-ncs-sdk/modules/lib/golioth/samples/settings
    rm -rf build
    <NCS environment setup>
    west build -b nrf9160dk_nrf9160_ns . -p
    <verify successful build>
    <delete semicolon in ~/golioth-ncs-sdk/modules/lib/golioth/net/golioth/golioth.c to force compile error>
    west build -b nrf9160dk_nrf9160_ns . -p
    <verify failed build>
```
- [x] Change Zephyr version, build in-tree sample
```
    cd ~/golioth-zephyr-sdk/modules/lib/golioth
    edit west.yml, change zephyr revision to main
    west update
    cd ~/golioth-zephyr-sdk/zephyr
    <verify commit is pointing to tip of upstream main>
    cd ~/golioth-zephyr-sdk/modules/lib/golioth/samples/settings
    rm -rf build
    <vanilla zephyr environment setup>
    west build -b nrf52840dk_nrf5840 . -p
    <verify built against latest zephyr>
        Actually failed to build, due to zcbor_common.h header missing, but this proves it was using most recent Zephyr
```
- [x] Change NCS version, build in-tree sample
```
    cd ~/golioth-ncs-sdk/modules/lib/golioth
    edit west-ncs.yml, change nrf revision to main
    west update
    cd ~/golioth-ncs-sdk/nrf
    <verify commit is pointing to tip of upstream main>
    cd ~/golioth-ncs-sdk/modules/lib/golioth/samples/settings
    rm -rf build
    <ncs environment setup>
    west build -b nrf9160dk_nrf9160_ns . -p
    <verify built against latest zephyr>
```

### Next Steps

* Confluence page documenting goals/motivation/reasoning for using this approach

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/188"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

