### PR TITLE
.github: fix job settings for docs main deployment

### DIFF
--- a/.github/workflows/firebase-doxygen-main.yml
+++ b/.github/workflows/firebase-doxygen-main.yml
@@ -4,7 +4,7 @@ name: Deploy Doxygen to Firebase Hosting on Main
     branches:
       - main
 jobs:
-  build_and_preview:
+  build_and_deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +18,9 @@ jobs:
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GOLIOTH }}'
+          channelId: live
           projectId: golioth
           target: docs-prod
           entryPoint: docs
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels


### PR DESCRIPTION
The job settings for the CI job that deploys docs live
on main were incorrectly set. The channelId and
FIREBASE_CLI_PREVIEWS were missing.

Signed-off-by: Nick Miller <nick@golioth.io>

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/194"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

### Testing

- [x] Temporarily change `main` to `nick/doxygen_hotfix`. Verify docs are deployed to firebase "live" docs: https://golioth-zephyr-sdk-doxygen.firebaseapp.com/